### PR TITLE
Fix Gem Versions and needs_migration? Method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,38 +1,40 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # An object-relational mapper
 # https://guides.rubyonrails.org/active_record_basics.html
-gem "activerecord"
+gem 'activerecord'
 
 # Configures common Rake tasks for working with Active Record
 # https://github.com/sinatra-activerecord/sinatra-activerecord
-gem "sinatra-activerecord"
+gem 'sinatra-activerecord'
 
 # Run common tasks from the command line
 # https://github.com/ruby/rake
-gem "rake"
+gem 'rake'
 
 # Provides functionality to interact with a SQLite3 database
 # https://github.com/sparklemotion/sqlite3-ruby
-gem "sqlite3"
+gem 'sqlite3'
 
 # Require all files in a folder
 # https://github.com/jarmo/require_all
-gem "require_all"
+gem 'require_all'
 
 # Used to make network requests
 # https://github.com/rest-client/rest-client
-gem "rest-client"
+gem 'rest-client'
+
+gem 'ostruct'
+
+gem 'rubocop'
 
 # These gems will only be used when we are running the application locally
 group :development do
-  gem "pry"
+  gem 'pry'
 end
 
 # These gems will only be used when we are running tests
 group :test do
-  gem "database_cleaner"
-  gem "rspec"
+  gem 'database_cleaner'
+  gem 'rspec'
 end
-
-

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 # An object-relational mapper
 # https://guides.rubyonrails.org/active_record_basics.html
-gem "activerecord", "~> 6.1"
+gem "activerecord"
 
 # Configures common Rake tasks for working with Active Record
 # https://github.com/sinatra-activerecord/sinatra-activerecord
@@ -14,7 +14,7 @@ gem "rake"
 
 # Provides functionality to interact with a SQLite3 database
 # https://github.com/sparklemotion/sqlite3-ruby
-gem "sqlite3", "~> 1.4"
+gem "sqlite3"
 
 # Require all files in a folder
 # https://github.com/jarmo/require_all
@@ -22,7 +22,7 @@ gem "require_all"
 
 # Used to make network requests
 # https://github.com/rest-client/rest-client
-gem "rest-client", "~> 2.1"
+gem "rest-client"
 
 # These gems will only be used when we are running the application locally
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    ast (2.4.3)
     base64 (0.3.0)
     benchmark (0.4.1)
     bigdecimal (3.2.2)
@@ -40,6 +41,9 @@ GEM
       domain_name (~> 0.5)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    json (2.13.1)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
     logger (1.7.0)
     method_source (1.1.0)
     mime-types (3.7.0)
@@ -50,9 +54,16 @@ GEM
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
     netrc (0.11.0)
+    ostruct (0.6.3)
+    parallel (1.27.0)
+    parser (3.3.9.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.4.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    racc (1.8.1)
     rack (3.1.16)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
@@ -61,7 +72,9 @@ GEM
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
+    rainbow (3.1.1)
     rake (13.3.0)
+    regexp_parser (2.10.0)
     require_all (3.0.0)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -81,6 +94,22 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.4)
+    rubocop (1.79.0)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.46.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      tsort (>= 0.2.0)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.46.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     securerandom (0.4.1)
     sinatra (4.1.1)
@@ -105,8 +134,12 @@ GEM
     sqlite3 (2.7.3-x86_64-linux-musl)
     tilt (2.6.1)
     timeout (0.4.3)
+    tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
     uri (1.0.3)
 
 PLATFORMS
@@ -124,11 +157,13 @@ PLATFORMS
 DEPENDENCIES
   activerecord
   database_cleaner
+  ostruct
   pry
   rake
   require_all
   rest-client
   rspec
+  rubocop
   sinatra-activerecord
   sqlite3
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,98 +1,136 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.4)
-      activesupport (= 6.1.4)
-    activerecord (6.1.4)
-      activemodel (= 6.1.4)
-      activesupport (= 6.1.4)
-    activesupport (6.1.4)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activemodel (8.0.2)
+      activesupport (= 8.0.2)
+    activerecord (8.0.2)
+      activemodel (= 8.0.2)
+      activesupport (= 8.0.2)
+      timeout (>= 0.4.0)
+    activesupport (8.0.2)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    base64 (0.3.0)
+    benchmark (0.4.1)
+    bigdecimal (3.2.2)
     coderay (1.1.3)
-    concurrent-ruby (1.1.9)
-    database_cleaner (2.0.1)
-      database_cleaner-active_record (~> 2.0.0)
-    database_cleaner-active_record (2.0.1)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.3)
+    database_cleaner (2.1.0)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.2.1)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    diff-lcs (1.4.4)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
+    diff-lcs (1.6.2)
+    domain_name (0.6.20240107)
+    drb (2.2.3)
     http-accept (1.7.0)
-    http-cookie (1.0.4)
+    http-cookie (1.0.8)
       domain_name (~> 0.5)
-    i18n (1.8.10)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    method_source (1.0.0)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0704)
-    minitest (5.14.4)
-    mustermann (1.1.1)
+    logger (1.7.0)
+    method_source (1.1.0)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2025.0722)
+    minitest (5.25.5)
+    mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
     netrc (0.11.0)
-    pry (0.14.1)
+    pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rack (2.2.3)
-    rack-protection (2.1.0)
-      rack
-    rake (13.0.6)
+    rack (3.1.16)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rake (13.3.0)
     require_all (3.0.0)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.2)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.2)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.4)
     ruby2_keywords (0.0.5)
-    sinatra (2.1.0)
-      mustermann (~> 1.0)
-      rack (~> 2.2)
-      rack-protection (= 2.1.0)
+    securerandom (0.4.1)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
-    sinatra-activerecord (2.0.23)
+    sinatra-activerecord (2.0.28)
       activerecord (>= 4.1)
       sinatra (>= 1.0)
-    sqlite3 (1.4.2)
-    tilt (2.0.10)
-    tzinfo (2.0.4)
+    sqlite3 (2.7.3-aarch64-linux-gnu)
+    sqlite3 (2.7.3-aarch64-linux-musl)
+    sqlite3 (2.7.3-arm-linux-gnu)
+    sqlite3 (2.7.3-arm-linux-musl)
+    sqlite3 (2.7.3-arm64-darwin)
+    sqlite3 (2.7.3-x86-linux-gnu)
+    sqlite3 (2.7.3-x86-linux-musl)
+    sqlite3 (2.7.3-x86_64-darwin)
+    sqlite3 (2.7.3-x86_64-linux-gnu)
+    sqlite3 (2.7.3-x86_64-linux-musl)
+    tilt (2.6.1)
+    timeout (0.4.3)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.7)
-    zeitwerk (2.4.2)
+    uri (1.0.3)
 
 PLATFORMS
-  universal-darwin-20
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
-  activerecord (~> 6.1)
+  activerecord
   database_cleaner
   pry
   rake
   require_all
-  rest-client (~> 2.1)
+  rest-client
   rspec
   sinatra-activerecord
-  sqlite3 (~> 1.4)
+  sqlite3
 
 BUNDLED WITH
-   2.2.23
+   2.7.1

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_18_144445) do
-
+ActiveRecord::Schema[8.0].define(version: 2021_07_18_144445) do
   create_table "spells", force: :cascade do |t|
     t.string "name"
     t.integer "level"
     t.string "description"
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,13 +3,8 @@ require_relative "../config/environment"
 require "sinatra/activerecord/rake"
 
 RSpec.configure do |config|
-  # Database setup
-  if ActiveRecord::Base.connection.migration_context.needs_migration?
-    # Run migrations for test environment
-    Rake::Task["db:migrate"].execute
-  end
-
   config.before(:suite) do
+    Rake::Task["db:migrate"].execute
     DatabaseCleaner.clean_with(:truncation)
   end
 
@@ -36,6 +31,6 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
-  
+
   config.shared_context_metadata_behavior = :apply_to_host_groups
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
 ENV['RACK_ENV'] ||= 'test'
-require_relative "../config/environment"
-require "sinatra/activerecord/rake"
+require_relative '../config/environment'
+require 'sinatra/activerecord/rake'
 
 RSpec.configure do |config|
   config.before(:suite) do
-    Rake::Task["db:migrate"].execute
+    Rake::Task['db:migrate'].execute
     DatabaseCleaner.clean_with(:truncation)
   end
 


### PR DESCRIPTION
This pull request includes updates to dependency versions in the `Gemfile` and adjustments to the database setup in the RSpec configuration to streamline test execution. The most important changes are grouped below:

### Dependency Updates:
* Removed version constraints for the `activerecord`, `sqlite3`, and `rest-client` gems in the `Gemfile`, allowing the latest versions to be used. (`[[1]](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fL5-R5)`, `[[2]](diffhunk://#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55fL17-R25)`)

### Test Configuration Changes:
* Moved the database migration execution from a conditional check in the main RSpec configuration to the `before(:suite)` block, ensuring migrations are consistently run before tests. (`[spec/spec_helper.rbL6-R7](diffhunk://#diff-89eebfcbc0f14b6d989517837ca1e94fce4e2ce9a03233641cd936f2b8d2ed94L6-R7)`)